### PR TITLE
do not check thinprovisioned volumes

### DIFF
--- a/nagios/bin/pmp-check-lvm-snapshots
+++ b/nagios/bin/pmp-check-lvm-snapshots
@@ -31,8 +31,8 @@ check_lvm_snapshot_fullness() {
    local FILE="$1"
    local FULL="$2"
    awk -v full="$FULL" '
-      $1 != "LV" && $1 != "File" && $3 ~ /^s/ && $6 !~ /[^0-9.]/ && $6 > full {
-         print $2 "/" $1 "[" $5 "]=" $6 "%"
+      $1 != "LV" && $1 != "File" && $3 ~ /snapshot/ && $5 !~ /[^0-9.]/ && $5 > full {
+         print $2 "/" $1 "[" $4 "]=" $5 "%"
       }' "${FILE}"
 }
 
@@ -71,7 +71,7 @@ main() {
    # the output of lvs.
    PATH="$PATH:/usr/sbin:/sbin"
    if [ -z "$1" ]; then
-      lvs > "${TEMP}" 2>&1
+      lvs --noheadings -o lv_name,vg_name,role,origin,snap_percent > "${TEMP}" 2>&1
    else
       cat "$1" > "${TEMP}" 2>/dev/null # For testing only
    fi

--- a/nagios/bin/pmp-check-lvm-snapshots
+++ b/nagios/bin/pmp-check-lvm-snapshots
@@ -31,7 +31,7 @@ check_lvm_snapshot_fullness() {
    local FILE="$1"
    local FULL="$2"
    awk -v full="$FULL" '
-      $1 != "LV" && $1 != "File" && $6 !~ /[^0-9.]/ && $6 > full {
+      $1 != "LV" && $1 != "File" && $3 ~ /^s/ && $6 !~ /[^0-9.]/ && $6 > full {
          print $2 "/" $1 "[" $5 "]=" $6 "%"
       }' "${FILE}"
 }


### PR DESCRIPTION
Hi,

while playing with check-lvm-snapshots on my laptop, I noticed that it would also look at the thin volumes I have. For those, reporting 100% is just fine (it just means they are not so thin anymore).

To fix that, I changed the code to check only volumes that have the "snapshot" role and to look at the "snap_percent" column, not the "data_percent" one.

Enjoy!