### PR TITLE
Build Nagios plugin DEB package in /usr/lib

### DIFF
--- a/build/deb/percona-nagios-plugins/files
+++ b/build/deb/percona-nagios-plugins/files
@@ -1,7 +1,7 @@
 #!/bin/sh
 SOURCE_DIR=$1
 DEST_DIR=$2
-LIBDIR=/usr/lib64
+LIBDIR=/usr/lib
 cd $SOURCE_DIR
 install -m 0755 -d $DEST_DIR/$LIBDIR/nagios/plugins
 install -m 0755 nagios/bin/pmp-* $DEST_DIR/$LIBDIR/nagios/plugins

--- a/build/deb/percona-nagios-plugins/postinst
+++ b/build/deb/percona-nagios-plugins/postinst
@@ -1,3 +1,3 @@
 #!/bin/sh
 echo
-echo "Plugins are installed to /usr/lib64/nagios/plugins"
+echo "Plugins are installed to /usr/lib/nagios/plugins"


### PR DESCRIPTION
The `percona-nagios-plugins`  Debian/Ubuntu package installs the Nagios plugins in `/usr/lib64/...` instead of `/usr/lib/...` like all the other Nagios plugins, see for example the [nagios-plugins-contrib](https://packages.debian.org/sid/amd64/nagios-plugins-contrib/filelist) package.

See the Multiarch pages for Debian and Ubuntu that explains their implementation to support multiarch:
 * https://wiki.debian.org/Multiarch
 * https://wiki.debian.org/Multiarch/TheCaseForMultiarch
 * https://wiki.ubuntu.com/MultiarchSpec

This PR moves the installation dir of the Nagios plugins for the DEB packages to `/usr/lib/nagios/plugins` in accordance with Debian/Ubuntu multiarch implementation.

