### PR TITLE
Fix --unconfigured on replication-delay check

### DIFF
--- a/nagios/bin/pmp-check-mysql-replication-delay
+++ b/nagios/bin/pmp-check-mysql-replication-delay
@@ -93,7 +93,7 @@ main() {
       NOTE="${LEVEL:-0} seconds of replication delay"
       if [ "${LEVEL:-""}" = "NULL" ]; then
          NOTE="UNK replica is stopped"
-      elif [ "-z ${LEVEL}" -a "${OPT_REPLNOTSET}" ]; then
+      elif [ -z "${LEVEL}" -a "${OPT_REPLNOTSET}" ]; then
          NOTE="UNK This server is not configured as a replica."
       # pt-slave-delayed slave
       elif [ "${LEVEL:-0}" -lt "${OPT_MIN}" ]; then


### PR DESCRIPTION
The `--unconfigured` flag of `pmp-check-mysql-replication-delay` was returning unknown when I was expecting it to pass, and I think this is the culprit.