### PR TITLE
rpearce: Prevent infinite hang of pmp-check-mysql-replication-delay when -T is specified but -S is not 'MASTER'

### DIFF
--- a/nagios/bin/pmp-check-mysql-replication-delay
+++ b/nagios/bin/pmp-check-mysql-replication-delay
@@ -64,6 +64,7 @@ main() {
       fi
    fi
 
+   get_slave_status $1
    # Get replication delay from a heartbeat table or from SHOW SLAVE STATUS.
    if [ "${OPT_TABLE}" ]; then
       if [ -z "${OPT_UTC}" ]; then
@@ -72,18 +73,15 @@ main() {
          NOW_FUNC='UNIX_TIMESTAMP(UTC_TIMESTAMP)'
       fi
       if [ "${OPT_SRVID}" == "MASTER" ]; then
-        get_slave_status $1
         if [ "${MYSQL_CONN}" = 0 ]; then
           OPT_SRVID=$(awk '/Master_Server_Id/{print $2}' "${TEMP_SLAVEDATA}")
         fi
       fi
-      get_slave_status $1
       SQL="SELECT MAX(${NOW_FUNC} - ROUND(UNIX_TIMESTAMP(ts))) AS delay
          FROM ${OPT_TABLE} WHERE (${OPT_SRVID:-0} = 0 OR server_id = ${OPT_SRVID:-0})"
       LEVEL=$(mysql_exec "${SQL}")
       MYSQL_CONN=$?
    else
-      get_slave_status $1
       if [ "${MYSQL_CONN}" = 0 ]; then
          LEVEL=$(awk '/Seconds_Behind_Master/{print $2}' "${TEMP_SLAVEDATA}")
       fi

--- a/nagios/bin/pmp-check-mysql-replication-delay
+++ b/nagios/bin/pmp-check-mysql-replication-delay
@@ -77,6 +77,7 @@ main() {
           OPT_SRVID=$(awk '/Master_Server_Id/{print $2}' "${TEMP_SLAVEDATA}")
         fi
       fi
+      get_slave_status $1
       SQL="SELECT MAX(${NOW_FUNC} - ROUND(UNIX_TIMESTAMP(ts))) AS delay
          FROM ${OPT_TABLE} WHERE (${OPT_SRVID:-0} = 0 OR server_id = ${OPT_SRVID:-0})"
       LEVEL=$(mysql_exec "${SQL}")


### PR DESCRIPTION
Currently, if you specify -T <table> and do not specify -S MASTER  pmp-check-mysql-replication-delay will hang forever on this line: 
LAST_SLAVE_ERRNO=$(awk '/Last_SQL_Errno/{print $2}' "${TEMP_SLAVEDATA}")

The awk command is waiting for $TEMP_SLAVEDATA which has no value.
$TEMP_SLAVEDATA is only set by get_slave_status, which is never called in this case.

The below fix adds the missing call to get_slave_status. 
I am however sad that this is now duplicated 3 times, it might make more sense just to call it once.

I have just added another commit that will only call get_slave_status once instead of 3 times
