### PR TITLE
Slaves alert due to deadlocks on the master

### DIFF
--- a/nagios/bin/pmp-check-mysql-deadlocks
+++ b/nagios/bin/pmp-check-mysql-deadlocks
@@ -60,7 +60,7 @@ main() {
       fi
    fi
 
-   LEVEL=$(mysql_exec "SELECT COUNT(*) FROM ${OPT_TABLE} WHERE ts >= NOW() - INTERVAL ${OPT_INTERVAL}*60 SECOND")
+   LEVEL=$(mysql_exec "SELECT COUNT(*) FROM ${OPT_TABLE} WHERE server = '${OPT_HOST}' AND ts >= NOW() - INTERVAL ${OPT_INTERVAL}*60 SECOND")
    if [ $? = 0 ]; then
       NOTE="${LEVEL:-UNKNOWN} deadlocks in last ${OPT_INTERVAL} minutes"
       if [ "${LEVEL:-0}" -gt "${OPT_CRIT}" ]; then
@@ -163,7 +163,7 @@ C<SELECT> from the C<pt-deadlock-logger> table.
 
 =back
 
-This plugin executes no UNIX commands that may need special privileges. 
+This plugin executes no UNIX commands that may need special privileges.
 
 =head1 COPYRIGHT, LICENSE, AND WARRANTY
 

--- a/nagios/bin/pmp-check-mysql-deadlocks
+++ b/nagios/bin/pmp-check-mysql-deadlocks
@@ -60,9 +60,6 @@ main() {
       fi
    fi
 
-   # Sanitise variables for SQL
-
-
    LEVEL=$(mysql_exec "SELECT COUNT(*) FROM ${OPT_TABLE} WHERE server IN ('${OPT_HOST}', @@hostname) AND ts >= NOW() - INTERVAL ${OPT_INTERVAL}*60 SECOND")
    if [ $? = 0 ]; then
       NOTE="${LEVEL:-UNKNOWN} deadlocks in last ${OPT_INTERVAL} minutes"

--- a/nagios/bin/pmp-check-mysql-deadlocks
+++ b/nagios/bin/pmp-check-mysql-deadlocks
@@ -60,7 +60,10 @@ main() {
       fi
    fi
 
-   LEVEL=$(mysql_exec "SELECT COUNT(*) FROM ${OPT_TABLE} WHERE server = '${OPT_HOST}' AND ts >= NOW() - INTERVAL ${OPT_INTERVAL}*60 SECOND")
+   # Sanitise variables for SQL
+
+
+   LEVEL=$(mysql_exec "SELECT COUNT(*) FROM ${OPT_TABLE} WHERE server IN ('${OPT_HOST}', @@hostname) AND ts >= NOW() - INTERVAL ${OPT_INTERVAL}*60 SECOND")
    if [ $? = 0 ]; then
       NOTE="${LEVEL:-UNKNOWN} deadlocks in last ${OPT_INTERVAL} minutes"
       if [ "${LEVEL:-0}" -gt "${OPT_CRIT}" ]; then


### PR DESCRIPTION
If the check is enabled on replicas within the same tree then a deadlock on the master triggers alerts on the slave. Using the value of `OPT_HOST` to restrict `deadlocks.server = ?` seems to be the obvious fix here:

**Before**
```
[mon1]> /usr/lib64/nagios/plugins/pmp-check-mysql-deadlocks -H 10.0.1.14 -i 120 -w 12 -c 60
OK 2 deadlocks in last 120 minutes | deadlocks=2;12;60;0;
[mon1]> /usr/lib64/nagios/plugins/pmp-check-mysql-deadlocks -H 10.0.1.13 -i 120 -w 12 -c 60
OK 2 deadlocks in last 120 minutes | deadlocks=2;12;60;0;
```
**After**
```
[mon1]> /usr/lib64/nagios/plugins/pmp-check-mysql-deadlocks -H 10.0.1.14 -i 120 -w 12 -c 60
OK 2 deadlocks in last 120 minutes | deadlocks=2;12;60;0;
[mon1]> /usr/lib64/nagios/plugins/pmp-check-mysql-deadlocks -H 10.0.1.13 -i 120 -w 12 -c 60
OK 0 deadlocks in last 120 minutes | deadlocks=0;12;60;0;
```
