### PR TITLE
Moved get_slave_status out of nested if block

### DIFF
--- a/nagios/bin/pmp-check-mysql-replication-delay
+++ b/nagios/bin/pmp-check-mysql-replication-delay
@@ -66,13 +66,13 @@ main() {
 
    # Get replication delay from a heartbeat table or from SHOW SLAVE STATUS.
    if [ "${OPT_TABLE}" ]; then
+      get_slave_status $1
       if [ -z "${OPT_UTC}" ]; then
          NOW_FUNC='UNIX_TIMESTAMP()'
       else
          NOW_FUNC='UNIX_TIMESTAMP(UTC_TIMESTAMP)'
       fi
       if [ "${OPT_SRVID}" == "MASTER" ]; then
-        get_slave_status $1
         if [ "${MYSQL_CONN}" = 0 ]; then
           OPT_SRVID=$(awk '/Master_Server_Id/{print $2}' "${TEMP_SLAVEDATA}")
         fi


### PR DESCRIPTION
There was a path through the if/else block that would result in get_slave_status not being called. In that case, TEMP_SLAVEDATA was never set. This line:

{code}   LAST_SLAVE_ERRNO=$(awk '/Last_SQL_Errno/{print $2}' "${TEMP_SLAVEDATA}"){code}

would hang forever if the -T option was set, but the -s option was not.