### PR TITLE
Fixed false-positive when calculated delay was <0 and -m was not set

### DIFF
--- a/nagios/bin/pmp-check-mysql-replication-delay
+++ b/nagios/bin/pmp-check-mysql-replication-delay
@@ -105,7 +105,7 @@ main() {
       elif [ -z "${LEVEL}" -a "${OPT_REPLNOTSET}" ]; then
          NOTE="UNK This server is not configured as a replica."
       # pt-slave-delayed slave
-      elif [ "${LEVEL:-0}" -lt "${OPT_MIN}" ]; then
+      elif [ ${MIN_DELAY_SET} -eq 1 ] && [ "${LEVEL:-0}" -lt "${OPT_MIN}" ]; then
          NOTE="CRIT (delayed slave) $NOTE | $PERFDATA"
       elif [ "${LEVEL:-0}" -gt "${OPT_CRIT}" ]; then
          NOTE="CRIT $NOTE | $PERFDATA"


### PR DESCRIPTION
Addresses the following issue that can occur if system clocks are slightly off:


```
/usr/lib64/nagios/plugins/pmp-check-mysql-replication-delay -H 10.0.0.2 -w 3600 -c 14400 -T percona.heartbeat -s MASTER -u
CRIT (delayed slave) -1 seconds of replication delay | replication_delay=-1;3600;14400;0;
```
