### PR TITLE
Change template for TMPFILE

### DIFF
--- a/make.sh
+++ b/make.sh
@@ -27,7 +27,7 @@ function _md5() {
 }
 
 # Set up a temp file.
-TEMPFILE=$(mktemp /tmp/${0##*/}.XXXX)
+TEMPFILE=$(mktemp /tmp/${0##*/}.XXXXXX)
 
 # Set up the release directory.  Copy things into the directory so
 # we can alter them without messing with stuff that is under source control.


### PR DESCRIPTION
On my system (Slackware64 14.2) the following command fails:

`$ mktemp /tmp/make.sh.XXXX
mktemp: cannot create temp file /tmp/make.sh.XXXX: Invalid argument`

because the pattern should consist of 6 'Xs' according to the manual. Thus the following works like charm:

`$ mktemp /tmp/make.sh.XXXXXX
/tmp/make.sh.KVw3rQ`

In the source tarball, I found only make.sh and util/generate-nagios-config to still be with 4 'Xs'. Please, consider changing the pattern, so the script doesn't fail.