### PR TITLE
Change mktemp pattern

### DIFF
--- a/make.sh
+++ b/make.sh
@@ -27,7 +27,7 @@ function _md5() {
 }
 
 # Set up a temp file.
-TEMPFILE=$(mktemp /tmp/${0##*/}.XXXX)
+TEMPFILE=$(mktemp /tmp/${0##*/}.XXXXXX)
 
 # Set up the release directory.  Copy things into the directory so
 # we can alter them without messing with stuff that is under source control.

--- a/util/generate-nagios-config
+++ b/util/generate-nagios-config
@@ -4,7 +4,7 @@ set -e
 set -u
 
 PRJ="Percona Monitoring Plugins"
-TEMP=$(mktemp "/tmp/${0##*/}-nagios-setup.XXXX")
+TEMP=$(mktemp "/tmp/${0##*/}-nagios-setup.XXXXXX")
 trap 'rm -rf "${TEMP}" >/dev/null 2>&1' EXIT
 read -e -p "Configuration file prefix to use [/etc/nagios/objects]: " DIR
 DIR="${DIR:-/etc/nagios/objects}"


### PR DESCRIPTION
On my system (Slackware64 14.2) the following command fails:

`$ mktemp /tmp/make.sh.XXXX
mktemp: cannot create temp file /tmp/make.sh.XXXX: Invalid argument`

because the pattern should consist of 6 'Xs' according to the manual. Thus the following works like charm:

`$ mktemp /tmp/make.sh.XXXXXX
/tmp/make.sh.KVw3rQ`

In the source tarball, I found only make.sh and util/generate-nagios-config to still be with 4 'Xs', so I'm providing here the necessary fixes. Please, consider applying them, to avoid unexpected errors on some systems.