### PR TITLE
Issue 52: if using pt-heartbeat, get_slave_status is only called when -s is set to MASTER

### DIFF
--- a/nagios/bin/pmp-check-mysql-replication-delay
+++ b/nagios/bin/pmp-check-mysql-replication-delay
@@ -65,6 +65,7 @@ main() {
    fi
 
    # Get replication delay from a heartbeat table or from SHOW SLAVE STATUS.
+   get_slave_status $1
    if [ "${OPT_TABLE}" ]; then
       if [ -z "${OPT_UTC}" ]; then
          NOW_FUNC='UNIX_TIMESTAMP()'
@@ -72,7 +73,6 @@ main() {
          NOW_FUNC='UNIX_TIMESTAMP(UTC_TIMESTAMP)'
       fi
       if [ "${OPT_SRVID}" == "MASTER" ]; then
-        get_slave_status $1
         if [ "${MYSQL_CONN}" = 0 ]; then
           OPT_SRVID=$(awk '/Master_Server_Id/{print $2}' "${TEMP_SLAVEDATA}")
         fi
@@ -82,7 +82,6 @@ main() {
       LEVEL=$(mysql_exec "${SQL}")
       MYSQL_CONN=$?
    else
-      get_slave_status $1
       if [ "${MYSQL_CONN}" = 0 ]; then
          LEVEL=$(awk '/Seconds_Behind_Master/{print $2}' "${TEMP_SLAVEDATA}")
       fi


### PR DESCRIPTION
[Issue 52](https://github.com/percona/percona-monitoring-plugins/issues/52)
The slave status is required to check for errors, but if using `pt-heartbeat` this is not always requested

Forcing `get_slave_status` to be called ahead of the check for which kind of check to perform resolves the issue:
```
 ⇒ bash pmp-check-mysql-replication-delay --defaults-file ~/sandbox/x3_mysql_5628/node1/my.sandbox.cnf -T percona.heartbeat -s 1
OK 0 seconds of replication delay | replication_delay=0;300;600;0;
 ⇒ bash pmp-check-mysql-replication-delay --defaults-file ~/sandbox/x3_mysql_5628/node1/my.sandbox.cnf -T percona.heartbeat -s MASTER
OK 0 seconds of replication delay | replication_delay=0;300;600;0;
 ⇒ bash pmp-check-mysql-replication-delay --defaults-file ~/sandbox/x3_mysql_5628/node1/my.sandbox.cnf                               
OK 0 seconds of replication delay | replication_delay=0;300;600;0;
```