### PR TITLE
Use = for [ ... ] tests instead of bash's ==

### DIFF
--- a/nagios/bin/pmp-check-mysql-replication-delay
+++ b/nagios/bin/pmp-check-mysql-replication-delay
@@ -73,7 +73,7 @@ main() {
       else
          NOW_FUNC='UNIX_TIMESTAMP(UTC_TIMESTAMP)'
       fi
-      if [ "${OPT_SRVID}" == "MASTER" ]; then
+      if [ "${OPT_SRVID}" = "MASTER" ]; then
         if [ "${MYSQL_CONN}" = 0 ]; then
           OPT_SRVID=$(awk '/Master_Server_Id/{print $2}' "${TEMP_SLAVEDATA}")
         fi

--- a/nagios/bin/pmp-check-mysql-ts-count
+++ b/nagios/bin/pmp-check-mysql-ts-count
@@ -61,10 +61,10 @@ main() {
          exit 1
       fi
    fi
-   if [ "${OPT_TARGET}" == "kills" ]; then
+   if [ "${OPT_TARGET}" = "kills" ]; then
       OPT_TABLE="${OPT_TABLE:-percona.kill_log}"
       OPT_TIMESTAMP="${OPT_TIMESTAMP:-timestamp}"
-   elif [ "${OPT_TARGET}" == "fkerrors" ]; then
+   elif [ "${OPT_TARGET}" = "fkerrors" ]; then
       OPT_TABLE="${OPT_TABLE:-percona.foreign_key_errors}"
       OPT_TIMESTAMP="${OPT_TIMESTAMP:-ts}"
    else


### PR DESCRIPTION
For Bash, the builtin command `test` resp. `[` accepts both `==` as well as `=` as an operator. POSIX however only specifies `=`. Thus, if the scripts are used with a `/bin/sh` which is not Bash, e.g. dash on Debian derivates, the test fail with:

```
[: 1: unexpected operator
```

This commit ensures that only the POSIX-conformiing operator `=` is used. For Bash, it doesn't make any difference, for other shells, it ensures that the scripts still work.

This pull request is an alternative solution to #36 and should fix #17 and (at least part of) #32.