### PR TITLE
Updating Cacti template definition file.

### DIFF
--- a/cacti/definitions/memcached.def
+++ b/cacti/definitions/memcached.def
@@ -301,7 +301,7 @@
          hash         => 'hash_03_VER_9f11276b966fcf44ba08973c39e5c4ac',
          input_string => '<path_php_binary> -q <path_cacti>/scripts/ss_get_by_ssh.php '
                        . '--host <hostname> --type memcached --items <items> '
-                       . '--server <server>',
+                       . '--server <server> --port2 <port2>',
          inputs => [
             {  allow_nulls => '',
                hash        => 'hash_07_VER_1ac2b66fa9aa43f3c9b9b919277b4b01',

--- a/cacti/definitions/redis.def
+++ b/cacti/definitions/redis.def
@@ -162,7 +162,7 @@
          type_id      => 1,
          hash         => 'hash_03_VER_6cb78e25c814d7c81748d9017ef34050',
          input_string => '<path_php_binary> -q <path_cacti>/scripts/ss_get_by_ssh.php '
-                       . '--host <hostname> --type redis --items <items> ',
+                       . '--host <hostname> --type redis --items <items> --port2 <port2>',
          inputs => [
             {  allow_nulls => '',
                hash        => 'hash_07_VER_ceefc4380d71467ed5401804c0013316',


### PR DESCRIPTION
In templates created from 'memcached.def' and 'redis.def',
There is a text box to specify the port number,
Values entered in the text box are not reflected in the command.

I confirmed that it is reflected in the command by giving --port2 to input_string.