### PR TITLE
pmp-check-mongo: fixed check_balance

### DIFF
--- a/nagios/bin/pmp-check-mongo.py
+++ b/nagios/bin/pmp-check-mongo.py
@@ -537,7 +537,7 @@ class NagiosMongoChecks:
         # Loop through each ns and determine if it's balanced or not
         for ns in chunks:
             balanced = chunks[ns]['total'] / shardsCount
-            for shard in chunks[ns]['shards']:
+            for shard in chunks[ns]['shards'].values():
                 if shard > balanced - threshold and shard < balanced + threshold:
                     pass
                 else:


### PR DESCRIPTION
Shards' names has small chance to be properly balanced, using number of chunks in shard may be a better option ;-)

```
>>> for i in {u'bdd4b386': 5, u'ba142fa9': 5, u'5904c137': 4}:
...   print(i)
... 
bdd4b386
ba142fa9
5904c137
```
