### PR TITLE
Correct issue with command line args from cacti

### DIFF
--- a/cacti/scripts/ss_get_by_ssh.php
+++ b/cacti/scripts/ss_get_by_ssh.php
@@ -245,7 +245,7 @@ function parse_cmdline( $args ) {
          $param = substr($p, 2);
          $value = null;
          $nextparam = current($args);
-         if ($nextparam !== false && strpos($nextparam, '--') !==0) {
+         if (!empty($nextparam) && strpos($nextparam, '--') !==0) {
             list($tmp, $value) = each($args);
          }
          $options[$param] = $value;

--- a/cacti/scripts/ss_get_mysql_stats.php
+++ b/cacti/scripts/ss_get_mysql_stats.php
@@ -227,7 +227,7 @@ function parse_cmdline( $args ) {
          $param = substr($p, 2);
          $value = null;
          $nextparam = current($args);
-         if ($nextparam !== false && strpos($nextparam, '--') !==0) {
+         if (!empty($nextparam) && strpos($nextparam, '--') !==0) {
             list($tmp, $value) = each($args);
          }
          $options[$param] = $value;


### PR DESCRIPTION
This corrects an issue with command line arguments that was found with later releases of Cacti when it introduced quotations around arguments.  This results in a blank string rather than null value.